### PR TITLE
ci: promote App IDs from secrets to vars

### DIFF
--- a/.github/workflows/docker-grade-check.yml
+++ b/.github/workflows/docker-grade-check.yml
@@ -41,9 +41,9 @@ jobs:
 
       - name: Fetch notebooks
         env:
-          GITHUB_APP_ID: ${{ secrets.OTTER_GH_APP_ID }}
+          GITHUB_APP_ID: ${{ vars.OTTER_AUTOGRADERS_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.OTTER_GH_APP_PRIVATE_KEY }}
-          GITHUB_APP_INSTALLATION_ID: ${{ secrets.OTTER_GH_APP_INSTALLATION_ID }}
+          GITHUB_APP_INSTALLATION_ID: ${{ vars.OTTER_AUTOGRADERS_INSTALLATION_ID }}
         run: |
           python tests/fetch_test_notebooks.py --courses "88ex,88bx,88cx,8x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.EDX_IMAGE_BUILDER_APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY_SECRET }}
           owner: edx-berkeley
 


### PR DESCRIPTION
## What

Promote App IDs and the installation ID from `secrets.*` to `vars.*` (IDs aren't sensitive). Rename for clarity.

| Old | New | Status |
|---|---|---|
| `vars.APP_ID` | `vars.EDX_IMAGE_BUILDER_APP_ID` | already set |
| `secrets.OTTER_GH_APP_ID` | `vars.OTTER_AUTOGRADERS_APP_ID` | already set (was secret) |
| `secrets.OTTER_GH_APP_INSTALLATION_ID` | `vars.OTTER_AUTOGRADERS_INSTALLATION_ID` | already set (was secret) |

Private-key secret names are **not** renamed here — that requires generating new keys + rotating. Tracked separately.

Mergeable as-is (new vars already exist, old secrets still referenced for keys only).

## Post-merge cleanup

```
gh secret delete OTTER_GH_APP_ID --repo <this repo>
gh secret delete OTTER_GH_APP_INSTALLATION_ID --repo <this repo>
gh variable delete APP_ID --repo <this repo>
```