### PR TITLE
ci: base auto-bumper checkout on staging, not default branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,17 @@ jobs:
           private-key: ${{ secrets.EDX_IMAGE_BUILDER_PRIVATE_KEY }}
           owner: edx-berkeley
 
+      # Base the auto-bumper branch on `staging`, not the default branch.
+      # The default branch (prod) is normally behind staging — basing the
+      # bump branch on prod and PR-ing into staging produces a huge diff
+      # where staging-only commits look like additions. Pinning to
+      # `staging` keeps the diff tight (single line in values.yaml).
       - name: Checkout edx-hub
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: edx-berkeley/edx-hub
+          ref: staging
           sparse-checkout: otter-service/
 
       - name: Set git identity


### PR DESCRIPTION
## Problem

When a release tag is pushed, the \`update-edx-hub\` job opens an auto-bumper PR in \`edx-berkeley/edx-hub\` bumping \`otter-service/values.yaml\`. The PR's base is staging, but \`actions/checkout\` was using the default branch (\`prod\`), so the branch was created from prod.

In edx-hub, \`prod\` is normally behind \`staging\` by several commits. A PR from a prod-based branch into staging therefore shows all of staging's newer commits as additions in the diff. The 2.0.18 release exposed this — auto-bumper PR #26 in edx-hub came out with **1,007 lines** of diff for a one-line tag bump, plus a merge conflict.

## Fix

Add \`ref: staging\` to the \`actions/checkout\` step. Diff stays a single line.

## Validation

- The companion edx-hub PR (deploy/otter-2.0.18 = #27) demonstrates what a clean bump looks like (1 line)
- After this merges + the next release tag is pushed, the auto-bumper output will match

🤖 Generated with [Claude Code](https://claude.com/claude-code)