### PR TITLE
fix: docker grade-check solution poll picks up student grade

### DIFF
--- a/tests/run_docker_grade_check.py
+++ b/tests/run_docker_grade_check.py
@@ -35,8 +35,13 @@ def submit_notebook(nb_path):
     print(f"  submitted {nb_path.name} → {resp.status_code}")
 
 
-def poll_for_grade(db, collection, user, course, assignment, deadline):
-    """Poll Firestore until a grade entry appears. Returns the grade float."""
+def poll_for_grade(db, collection, user, course, assignment, deadline, exclude_ids=None):
+    """
+    Poll Firestore until a grade entry appears. `exclude_ids` skips already-consumed
+    docs so the student/solution pair (same user/course/assignment) don't read the
+    same grade twice. Returns (grade, doc_ref).
+    """
+    exclude_ids = exclude_ids or set()
     while True:
         docs = (
             db.collection(collection)
@@ -45,9 +50,11 @@ def poll_for_grade(db, collection, user, course, assignment, deadline):
             .where("assignment", "==", assignment)
             .get()
         )
-        if docs:
-            grade = docs[-1].to_dict().get("grade")
-            return grade
+        candidates = [d for d in docs if d.id not in exclude_ids]
+        if candidates:
+            candidates.sort(key=lambda d: d.to_dict().get("timestamp", ""))
+            latest = candidates[-1]
+            return latest.to_dict().get("grade"), latest.reference
         if time.time() >= deadline:
             raise TimeoutError(
                 f"Timed out waiting for grade: user={user}, course={course}, assignment={assignment}"
@@ -76,6 +83,7 @@ def run_pair(db, collection_prefix, test_user, course, assignment):
 
     errors = []
     deadline = time.time() + POLL_TIMEOUT
+    consumed_ids = set()
 
     for role, nb_path, expected_grade in [
         ("student",  student_nb,  0.0),
@@ -84,7 +92,11 @@ def run_pair(db, collection_prefix, test_user, course, assignment):
         print(f"  Submitting {role} notebook ({course}/{assignment})...")
         try:
             submit_notebook(nb_path)
-            grade = poll_for_grade(db, f"{collection_prefix}-grades", test_user, course, assignment, deadline)
+            grade, doc_ref = poll_for_grade(
+                db, f"{collection_prefix}-grades", test_user, course, assignment, deadline,
+                exclude_ids=consumed_ids,
+            )
+            consumed_ids.add(doc_ref.id)
             if grade != expected_grade:
                 errors.append(
                     f"{course}/{assignment} {role}: expected grade {expected_grade}, got {grade}"


### PR DESCRIPTION
## Summary

Same shape of bug as [edx-hub#29](https://github.com/edx-berkeley/edx-hub/pull/29), validated and fixed there earlier today. In \`tests/run_docker_grade_check.py\`, student and solution submissions hit otter-service with the same \`user + course + assignment\`. The poll matches the student's grade doc the moment the solution is submitted and returns the student grade — solution always reports \`[FAIL] expected 1.0, got <student grade>\`.

Worse than the edx-hub variant: there's no timestamp filter at all here (the container uses a per-run \`collection_prefix\` for isolation), so any prior grade in the per-run collection would also match.

Fix: track consumed doc IDs across the pair, exclude them on the next poll, and sort matches by timestamp instead of taking \`docs[-1]\` from an unsorted list.

## Test plan

- [ ] Merge → dispatch the docker grade-check workflow → confirm solution grade = 1.0