### PR TITLE
ci: switch GCP_PROJECT to vars (matches org-level)

### DIFF
--- a/.github/workflows/docker-grade-check.yml
+++ b/.github/workflows/docker-grade-check.yml
@@ -24,7 +24,7 @@ jobs:
           docker run -d --name otter-pr -p 10101:10101 \
             -v ${HOME}/gcloud-service-key.json:/tmp/sa-key.json \
             -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa-key.json \
-            -e GCP_PROJECT_ID=${{ secrets.GCP_PROJECT }} \
+            -e GCP_PROJECT_ID=${{ vars.GCP_PROJECT }} \
             -e ENVIRONMENT=otter-ci-${{ github.run_id }} \
             -e LOG_LEVEL=INFO \
             otter-service:pr
@@ -83,7 +83,7 @@ jobs:
                   print(f"deleted {len(docs)} docs from otter-ci-{run_id}-{suffix}")
           EOF
         env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT }}
 
       - name: Notify Slack
         if: always()


### PR DESCRIPTION
## Summary

\`docker-grade-check.yml\` had 2 references to \`\${{ secrets.GCP_PROJECT }}\`. The project name (\"data8x-scratch\") isn't a secret — it lives at org level as a **variable**, not a secret. Once the per-repo secret is deleted, \`secrets.GCP_PROJECT\` would silently resolve to empty string.

Same fix as the parallel xDevs PR #29.

## Test plan

- [ ] PR's docker-grade-check run succeeds (validates \`vars.GCP_PROJECT\` resolves correctly from org level)
- [ ] After merge: delete repo-level \`secrets.GCP_PROJECT\` (last remaining repo-level entry in otter-service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)