### PR TITLE
ci: stop otter container before Firestore cleanup (fix orphan tornado-logs)

### DIFF
--- a/.github/workflows/docker-grade-check.yml
+++ b/.github/workflows/docker-grade-check.yml
@@ -64,6 +64,16 @@ jobs:
             exit 1
           fi
 
+      # Stop + remove the container BEFORE Firestore cleanup so the otter
+      # pod's "Shutdown finally" tornado-log is written first. Otherwise it
+      # lands after the cleanup runs and orphans an otter-ci-${run_id}-tornado-logs
+      # entry in Firestore.
+      - name: Stop otter container
+        if: always()
+        run: |
+          docker stop otter-pr 2>/dev/null || true
+          docker rm   otter-pr 2>/dev/null || true
+
       - name: Clean up Firestore CI collections
         if: always()
         run: |


### PR DESCRIPTION
## Summary

The docker-grade-check workflow leaves an orphan \`otter-ci-{run_id}-tornado-logs\` collection in Firestore after every run.

**Root cause**: the otter pod writes \`Shutdown finally\` to tornado-logs on container stop. The container was previously stopped only when the runner exited — AFTER the Firestore cleanup step had already run. So the shutdown log lands in a collection that the workflow no longer cleans.

**Three such orphans accumulated** since per-run isolation was added: runs 25975209173, 25975351526, 25993213385. All deleted manually out-of-band.

## Fix

Add an explicit \`docker stop otter-pr && docker rm otter-pr\` step before the cleanup, with \`if: always()\` so it runs on failure too. Container shutdown → tornado-log written → cleanup deletes it.

## Test plan

- [ ] Next docker-grade-check run on any PR leaves zero \`otter-ci-{run_id}-*\` collections in Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)