### PR TITLE
ci(slack): label docker-grade-check notification by workflow name

### DIFF
--- a/.github/workflows/docker-grade-check.yml
+++ b/.github/workflows/docker-grade-check.yml
@@ -102,4 +102,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            {"text": "${{ job.status == 'success' && '✅' || '❌' }} otter-service smoke test ${{ job.status }} — ${{ github.head_ref }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}
+            {"text": "${{ job.status == 'success' && '✅' || '❌' }} otter-service docker-grade-check ${{ job.status }} — ${{ github.head_ref }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}


### PR DESCRIPTION
Was `otter-service smoke test` — ambiguous since release.yml also has smoke-test steps. Matches the `{repo} {workflow} {status}` pattern used everywhere else.