### PR TITLE
ci: paths-ignore on PR-triggered workflows (skip doc-only changes)

### DIFF
--- a/.github/workflows/docker-grade-check.yml
+++ b/.github/workflows/docker-grade-check.yml
@@ -2,6 +2,12 @@ name: Docker Smoke Test
 
 on:
   pull_request_target:
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".github/**"
 
 jobs:
   docker-smoke-test:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,8 +3,20 @@ name: Python application
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".github/**"
   pull_request_target:
     branches: [ main ]
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".github/**"
 
 jobs:
   lint-and-build:


### PR DESCRIPTION
Stops docker-grade-check.yml + python-app.yml from running the full grading harness on doc-only PRs (README, CHANGELOG, LICENSE, docs/, .github/). Matches the pattern in edx-user-image. Saves ~5 min CI per doc PR.