### PR TITLE
feat: LTI 1.3 AGS grade-passback module (otter-service side)

### DIFF
--- a/src/otter_service/ags.py
+++ b/src/otter_service/ags.py
@@ -1,0 +1,198 @@
+"""LTI 1.3 Assignment & Grade Services (AGS) grade-passback.
+
+Companion to the LTI 1.1 `lis_outcome_service_url` XML/OAuth1 path in
+`otter_nb.post_grade()`. When a notebook submission comes in with LTI 1.3
+auth metadata (a `lineitem` URL and a platform `token_url`), we sign a
+client-credentials JWT with the tool's RS256 private key, exchange it for
+an OAuth2 access_token, and POST a Score to `<lineitem>/scores`.
+
+Reference implementation: `tools/lti13-poc/post_score.py` in the
+claude-memory-edx-berkeley repo. That script was used to prove the AGS
+dance end-to-end against Saltire (HTTP 204 = score accepted, the LTI 1.3
+spec response).
+
+The tool's RSA private key is read from the `LTI13_PRIVATE_KEY` env var
+(full PEM string) or `LTI13_PRIVATE_KEY_PATH` (path to a PEM file).
+`LTI13_CLIENT_ID` and optional `LTI13_KEY_ID` are also env-driven.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from pathlib import Path
+
+import aiohttp
+import async_timeout
+import jwt
+
+AGS_SCORE_SCOPE = "https://purl.imsglobal.org/spec/lti-ags/scope/score"
+DEFAULT_SCOPES = [AGS_SCORE_SCOPE]
+
+# Cache: token_url → (access_token, expires_at_epoch). Avoids signing a
+# fresh JWT and round-tripping the token endpoint on every submission.
+# Each token typically TTLs ~1h; we refresh at 90% of TTL to be safe.
+_TOKEN_CACHE: dict[str, tuple[str, float]] = {}
+
+
+class AGSError(Exception):
+    """Raised when AGS token exchange or score POST fails."""
+
+
+def _load_private_key_pem() -> str:
+    """Return the tool's RSA private key PEM string.
+
+    Prefers `LTI13_PRIVATE_KEY` (full PEM); falls back to
+    `LTI13_PRIVATE_KEY_PATH` (path to a PEM file on disk).
+    """
+    pem = os.environ.get("LTI13_PRIVATE_KEY")
+    if pem:
+        return pem
+    path = os.environ.get("LTI13_PRIVATE_KEY_PATH")
+    if path:
+        return Path(path).read_text()
+    raise AGSError(
+        "neither LTI13_PRIVATE_KEY nor LTI13_PRIVATE_KEY_PATH is set; "
+        "cannot sign AGS JWT"
+    )
+
+
+def _sign_client_assertion(client_id: str, token_url: str, key_id: str | None) -> str:
+    """Build and sign the client-credentials JWT (RS256)."""
+    pem = _load_private_key_pem()
+    now = int(time.time())
+    payload = {
+        "iss": client_id,
+        "sub": client_id,
+        "aud": token_url,
+        "iat": now,
+        "exp": now + 300,           # 5 min — short window per LTI spec
+        "jti": str(uuid.uuid4()),
+    }
+    headers = {"kid": key_id} if key_id else {}
+    return jwt.encode(payload, pem, algorithm="RS256", headers=headers)
+
+
+async def get_access_token(
+    token_url: str,
+    *,
+    scopes: list[str] | None = None,
+    client_id: str | None = None,
+    key_id: str | None = None,
+) -> str:
+    """Exchange a signed client-credentials JWT for an access_token.
+
+    Cached per token_url; refreshes when within 10% of expiry.
+    """
+    if scopes is None:
+        scopes = DEFAULT_SCOPES
+    if client_id is None:
+        client_id = os.environ.get("LTI13_CLIENT_ID")
+        if not client_id:
+            raise AGSError("LTI13_CLIENT_ID not set")
+    if key_id is None:
+        key_id = os.environ.get("LTI13_KEY_ID")  # optional
+
+    # cache check
+    cached = _TOKEN_CACHE.get(token_url)
+    if cached and cached[1] > time.time() + 30:
+        return cached[0]
+
+    assertion = _sign_client_assertion(client_id, token_url, key_id)
+    body = {
+        "grant_type": "client_credentials",
+        "client_assertion_type": (
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        ),
+        "client_assertion": assertion,
+        "scope": " ".join(scopes),
+    }
+    async with async_timeout.timeout(15):
+        async with aiohttp.ClientSession() as session:
+            async with session.post(token_url, data=body) as resp:
+                text = await resp.text()
+                if resp.status >= 400:
+                    raise AGSError(
+                        f"token exchange failed: HTTP {resp.status} {text[:300]}"
+                    )
+                data = await resp.json(content_type=None)
+
+    access_token = data["access_token"]
+    # expires_in is in seconds; cache until 90% of TTL has elapsed.
+    expires_in = float(data.get("expires_in", 3600))
+    _TOKEN_CACHE[token_url] = (access_token, time.time() + expires_in * 0.9)
+    return access_token
+
+
+async def post_score(
+    lineitem_url: str,
+    user_id: str,
+    score: float,
+    max_score: float,
+    *,
+    token_url: str,
+    activity_progress: str = "Completed",
+    grading_progress: str = "FullyGraded",
+    client_id: str | None = None,
+    key_id: str | None = None,
+) -> None:
+    """POST an LTI 1.3 Score JSON to `<lineitem>/scores`.
+
+    Per spec: HTTP 200 / 201 / 204 = success. Anything 4xx/5xx → AGSError.
+    """
+    access_token = await get_access_token(
+        token_url, scopes=[AGS_SCORE_SCOPE], client_id=client_id, key_id=key_id
+    )
+    url = lineitem_url.rstrip("/") + "/scores"
+    body = {
+        "userId": str(user_id),
+        "scoreGiven": float(score),
+        "scoreMaximum": float(max_score),
+        "activityProgress": activity_progress,
+        "gradingProgress": grading_progress,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/vnd.ims.lis.v1.score+json",
+    }
+    async with async_timeout.timeout(15):
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=body, headers=headers) as resp:
+                text = await resp.text()
+                if resp.status >= 400:
+                    raise AGSError(
+                        f"score POST failed: HTTP {resp.status} {text[:300]}"
+                    )
+
+
+def is_lti13_metadata(metadata: dict) -> bool:
+    """True if metadata carries the LTI 1.3 AGS fields needed to score.
+
+    Detection: presence of both `lineitem` URL and `token_url` (the
+    platform's OAuth2 token endpoint). These come from the launch JWT's
+    `https://purl.imsglobal.org/spec/lti-ags/claim/endpoint` claim,
+    captured into JH `auth_state` and forwarded by otter-submit in the
+    grade submission body.
+    """
+    return bool(metadata.get("lti13_lineitem") and metadata.get("lti13_token_url"))
+
+
+async def post_grade_lti13(metadata: dict, grade: float, max_score: float = 1.0) -> None:
+    """LTI 1.3 counterpart to `otter_nb.post_grade()`'s XML/OAuth1 path.
+
+    Expects metadata keys:
+        - lti13_lineitem: URL to the lineitem we're scoring
+        - lti13_token_url: platform's OAuth2 token endpoint
+        - userid: the LTI 1.3 `sub` claim (used as AGS userId)
+        - lti13_client_id: optional override; falls back to LTI13_CLIENT_ID env
+    """
+    await post_score(
+        lineitem_url=metadata["lti13_lineitem"],
+        user_id=metadata["userid"],
+        score=grade,
+        max_score=max_score,
+        token_url=metadata["lti13_token_url"],
+        client_id=metadata.get("lti13_client_id"),
+    )

--- a/src/otter_service/otter_nb.py
+++ b/src/otter_service/otter_nb.py
@@ -23,6 +23,7 @@ import tornado.escape
 import tornado.options
 import tornado.gen
 from otter_service import keys
+from otter_service import ags
 from otter_service.grade_assignment import grade_assignment
 import firebase_admin
 from firebase_admin import credentials, firestore
@@ -139,7 +140,28 @@ async def post_grade(solutions_base_path, metadata):
         - course: the course this notebook is in
         - section: the section this notebook is in
         - assignment:  the assignment name for this notebook
+
+    Dispatches to LTI 1.3 (AGS) if metadata carries `lti13_lineitem` +
+    `lti13_token_url` (populated by otter-submit from JH auth_state on LTI 1.3
+    launches). Otherwise falls through to the existing LTI 1.1 XML/OAuth1 path.
     """
+    if ags.is_lti13_metadata(metadata):
+        user_id = metadata["userid"]
+        grade = metadata["grade"]
+        max_score = float(metadata.get("max_score", 1.0))
+        try:
+            await ags.post_grade_lti13(metadata, grade=grade, max_score=max_score)
+            log_info_csv(
+                user_id,
+                metadata,
+                f"Posted to LTI 1.3 AGS: lineitem={metadata['lti13_lineitem']} score={grade}/{max_score}",
+            )
+            return
+        except ags.AGSError as e:
+            raise GradePostException(str(e)) from e
+        except Exception as ex:
+            raise Exception(f"Problem Posting Grade to LTI 1.3 AGS: {ex}") from ex
+
     body_hash = ""
     consumer_key = ""
     try:
@@ -275,6 +297,22 @@ class OtterHandler(HubOAuthenticated, tornado.web.RequestHandler):
             # in the future, assignment should be metadata in notebook
             if 'nb' in req_data:
                 notebook = req_data['nb']
+
+            # LTI 1.3 AGS endpoints (forwarded by otter-submit from JH
+            # auth_state when the user authenticated via LTI13Authenticator).
+            # When present, post_grade() dispatches to ags.post_grade_lti13()
+            # instead of the LTI 1.1 XML/OAuth1 path. Optional — LTI 1.1
+            # launches submit without this block and use the legacy path.
+            if 'lti13' in req_data:
+                lti13 = req_data['lti13'] or {}
+                metadata['lti13_lineitem'] = lti13.get('lineitem')
+                metadata['lti13_token_url'] = lti13.get('token_url')
+                metadata['lti13_client_id'] = lti13.get('client_id')
+                # AGS expects the LTI 1.3 `sub` claim as userId; otter-submit
+                # passes it through to ensure it matches what the platform
+                # registered the user as (may differ from the JH username).
+                if lti13.get('user_id'):
+                    metadata['userid'] = lti13['user_id']
 
             otter_check = "otter_service" in notebook['metadata']
             if otter_check and "course" in notebook['metadata']["otter_service"]:

--- a/tests/test_ags.py
+++ b/tests/test_ags.py
@@ -1,0 +1,195 @@
+"""Unit tests for otter_service.ags (LTI 1.3 AGS grade-passback).
+
+Coverage:
+- is_lti13_metadata: detection heuristic
+- _load_private_key_pem: env var path resolution + error cases
+- _sign_client_assertion: produces a JWT verifiable with the matching public key
+
+Network-level tests (token exchange, score POST) are deliberately out of
+scope here — those need a real platform endpoint and live as integration
+tests against Saltire (see tools/lti13-poc/post_score.py in the memory repo).
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import jwt
+import pytest
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+
+import otter_service.ags as ags
+
+
+# ---------------------- fixtures ----------------------
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Generate a throwaway RSA-2048 keypair as PEM strings (priv, pub)."""
+    key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    priv_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+@pytest.fixture
+def private_key_pem_file(tmp_path, rsa_keypair):
+    """Write the private key to a temp file and return its path."""
+    priv_pem, _ = rsa_keypair
+    p = tmp_path / "tool_private.pem"
+    p.write_text(priv_pem)
+    return p
+
+
+# ---------------------- is_lti13_metadata ----------------------
+
+
+def test_is_lti13_metadata_true_when_both_fields_present():
+    md = {
+        "userid": "29123",
+        "lti13_lineitem": "https://platform.example/lineitem/1",
+        "lti13_token_url": "https://platform.example/token",
+    }
+    assert ags.is_lti13_metadata(md) is True
+
+
+def test_is_lti13_metadata_false_lti11_shape():
+    md = {"userid": "abc", "course": "88e", "section": "1", "assignment": "lab01"}
+    assert ags.is_lti13_metadata(md) is False
+
+
+def test_is_lti13_metadata_false_when_lineitem_missing():
+    md = {"lti13_token_url": "https://platform.example/token"}
+    assert ags.is_lti13_metadata(md) is False
+
+
+def test_is_lti13_metadata_false_when_token_url_missing():
+    md = {"lti13_lineitem": "https://platform.example/lineitem/1"}
+    assert ags.is_lti13_metadata(md) is False
+
+
+def test_is_lti13_metadata_false_when_empty_strings():
+    md = {"lti13_lineitem": "", "lti13_token_url": ""}
+    assert ags.is_lti13_metadata(md) is False
+
+
+# ---------------------- _load_private_key_pem ----------------------
+
+
+def test_load_private_key_pem_prefers_env_var(monkeypatch, rsa_keypair, private_key_pem_file):
+    priv_pem, _ = rsa_keypair
+    # Both env vars set — env var wins, file path is ignored.
+    monkeypatch.setenv("LTI13_PRIVATE_KEY", priv_pem)
+    monkeypatch.setenv("LTI13_PRIVATE_KEY_PATH", str(private_key_pem_file))
+    out = ags._load_private_key_pem()
+    assert out == priv_pem
+
+
+def test_load_private_key_pem_falls_back_to_path(monkeypatch, rsa_keypair, private_key_pem_file):
+    priv_pem, _ = rsa_keypair
+    monkeypatch.delenv("LTI13_PRIVATE_KEY", raising=False)
+    monkeypatch.setenv("LTI13_PRIVATE_KEY_PATH", str(private_key_pem_file))
+    out = ags._load_private_key_pem()
+    assert out.strip() == priv_pem.strip()
+
+
+def test_load_private_key_pem_raises_when_neither_set(monkeypatch):
+    monkeypatch.delenv("LTI13_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("LTI13_PRIVATE_KEY_PATH", raising=False)
+    with pytest.raises(ags.AGSError, match="LTI13_PRIVATE_KEY"):
+        ags._load_private_key_pem()
+
+
+# ---------------------- _sign_client_assertion ----------------------
+
+
+def test_sign_client_assertion_produces_jwt_verifiable_by_public_key(
+    monkeypatch, rsa_keypair
+):
+    priv_pem, pub_pem = rsa_keypair
+    monkeypatch.setenv("LTI13_PRIVATE_KEY", priv_pem)
+
+    token = ags._sign_client_assertion(
+        client_id="my-tool", token_url="https://platform.example/token", key_id="kid-1"
+    )
+
+    # Decode using the matching public key; should succeed.
+    decoded = jwt.decode(
+        token,
+        pub_pem,
+        algorithms=["RS256"],
+        audience="https://platform.example/token",
+    )
+    assert decoded["iss"] == "my-tool"
+    assert decoded["sub"] == "my-tool"
+    assert decoded["aud"] == "https://platform.example/token"
+    assert "iat" in decoded and "exp" in decoded
+    assert decoded["exp"] - decoded["iat"] == 300  # 5 min window
+    assert "jti" in decoded
+
+    # Header should carry the kid we passed.
+    headers = jwt.get_unverified_header(token)
+    assert headers["kid"] == "kid-1"
+    assert headers["alg"] == "RS256"
+
+
+def test_sign_client_assertion_omits_kid_header_when_none(monkeypatch, rsa_keypair):
+    priv_pem, _ = rsa_keypair
+    monkeypatch.setenv("LTI13_PRIVATE_KEY", priv_pem)
+
+    token = ags._sign_client_assertion(
+        client_id="my-tool", token_url="https://platform.example/token", key_id=None
+    )
+    headers = jwt.get_unverified_header(token)
+    assert "kid" not in headers
+
+
+def test_sign_client_assertion_rejected_by_wrong_public_key(monkeypatch, rsa_keypair):
+    """Signed with key A → fails verification against key B's public part."""
+    priv_pem, _ = rsa_keypair
+    monkeypatch.setenv("LTI13_PRIVATE_KEY", priv_pem)
+
+    # Generate a different keypair; its public key shouldn't verify.
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other_pub = other.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    token = ags._sign_client_assertion(
+        client_id="my-tool", token_url="https://platform.example/token", key_id=None
+    )
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(
+            token,
+            other_pub,
+            algorithms=["RS256"],
+            audience="https://platform.example/token",
+        )
+
+
+# ---------------------- token cache ----------------------
+
+
+def test_token_cache_is_per_token_url(monkeypatch):
+    # Pure-Python cache check: same dict, different keys don't collide.
+    ags._TOKEN_CACHE.clear()
+    now = time.time()
+    ags._TOKEN_CACHE["https://a.example/token"] = ("token-A", now + 3600)
+    ags._TOKEN_CACHE["https://b.example/token"] = ("token-B", now + 3600)
+    assert ags._TOKEN_CACHE["https://a.example/token"][0] == "token-A"
+    assert ags._TOKEN_CACHE["https://b.example/token"][0] == "token-B"
+    ags._TOKEN_CACHE.clear()


### PR DESCRIPTION
## Summary
Adds an Assignment & Grade Services (AGS) path alongside the existing LTI 1.1 `lis_outcome_service_url` XML/OAuth1 code in `post_grade()`.

This is the **otter-service-side** of the LTI 1.3 grade-passback work. The dance was already proven end-to-end against Saltire on 2026-05-29 via a standalone Python script (`tools/lti13-poc/post_score.py` in the memory repo) — HTTP 204 score accepted. This PR transcribes that proven logic into the grading pipeline.

## New: `otter_service/ags.py`
- `get_access_token()` — signs an RS256 client-credentials JWT with the tool's private key, exchanges at the platform's token endpoint. **Per-token_url cache** (refreshes at 90% TTL) so we don't re-sign + round-trip on every submission.
- `post_score()` — POSTs an LTI 1.3 Score JSON to `<lineitem>/scores` per spec.
- `post_grade_lti13()` — per-submission entry point.
- `is_lti13_metadata()` — detection heuristic for dispatch.

## Wiring
- `post_grade()` in `otter_nb.py` now dispatches to AGS at the top when metadata carries `lti13_lineitem` + `lti13_token_url`. **LTI 1.1 launches submit without the `lti13` block and use the legacy path** — no behavior change for the existing flow.
- `OtterHandler.post()` reads an optional `lti13` block from the request body (`lineitem`, `token_url`, `client_id`, `user_id`). `otter-submit` will populate this from JH `auth_state` on LTI 1.3 launches (separate PR).

## Env vars (read at score-post time)
| var | meaning |
|---|---|
| `LTI13_PRIVATE_KEY` *(or)* `LTI13_PRIVATE_KEY_PATH` | tool's RSA private key — full PEM string, or path to a PEM file |
| `LTI13_CLIENT_ID` | the tool's client_id (overridable per-submission via `lti13.client_id`) |
| `LTI13_KEY_ID` | optional `kid` in the JWT header |

## Tests
`tests/test_ags.py` covers:
- `is_lti13_metadata` — 5 cases (positive, LTI 1.1 shape, missing fields, empty strings)
- Private key resolution — env-var precedence + file-path fallback + error path (3)
- JWT signing + verification via the matching public key + rejection via a different public key (3)
- Token cache shape (1)

**12/12 pass** in a clean venv with PyJWT[crypto] + pytest + aiohttp.

Network-level tests (live token exchange, score POST) live as the standalone POC — kept separate so this unit suite stays fast and offline.

## Out of scope (separate PRs to follow)
- **edx-hub**: subclass/hook on `LTI13Authenticator` to stash AGS claims into JH `auth_state`.
- **otter-submit**: read AGS claims from JH services API and forward in the submission body.
- **otter-service deploy**: wire `LTI13_PRIVATE_KEY` (or path) + `LTI13_CLIENT_ID` env vars into the staging otter-service Helm values.

After those three, a real LTI 1.3 launch from Saltire → JH spawn → notebook submit → AGS POST should run end-to-end and the score should land in Saltire's gradebook.

## Test plan
- [x] Unit tests pass (12/12)
- [ ] After companion PRs deploy to staging: real Saltire launch → notebook submit → score in Saltire gradebook
- [ ] Then file Stage 2 ticket with edX partner support to register the tool against real edx.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)