### PR TITLE
feat(ags): fetch lti13 metadata from JH auth_state instead of request body

### DIFF
--- a/src/otter_service/ags.py
+++ b/src/otter_service/ags.py
@@ -6,6 +6,13 @@ auth metadata (a `lineitem` URL and a platform `token_url`), we sign a
 client-credentials JWT with the tool's RS256 private key, exchange it for
 an OAuth2 access_token, and POST a Score to `<lineitem>/scores`.
 
+The lineitem URL, token_url, client_id, and sub claim are captured into
+the user's JH auth_state at launch time by a post_auth_hook on
+LTI13Authenticator (edx-hub common.yaml). OtterHandler.post fetches that
+auth_state via /hub/api/users/<name> (`fetch_user_auth_state`) using the
+otter_grade service token, which must carry the `read:users:auth_state`
+scope.
+
 Reference implementation: `tools/lti13-poc/post_score.py` in the
 claude-memory-edx-berkeley repo. That script was used to prove the AGS
 dance end-to-end against Saltire (HTTP 204 = score accepted, the LTI 1.3
@@ -17,7 +24,6 @@ The tool's RSA private key is read from the `LTI13_PRIVATE_KEY` env var
 """
 from __future__ import annotations
 
-import asyncio
 import os
 import time
 import uuid
@@ -173,10 +179,59 @@ def is_lti13_metadata(metadata: dict) -> bool:
     Detection: presence of both `lineitem` URL and `token_url` (the
     platform's OAuth2 token endpoint). These come from the launch JWT's
     `https://purl.imsglobal.org/spec/lti-ags/claim/endpoint` claim,
-    captured into JH `auth_state` and forwarded by otter-submit in the
-    grade submission body.
+    captured into JH `auth_state` by the post_auth_hook and pulled into
+    otter-service via fetch_user_auth_state() below.
     """
     return bool(metadata.get("lti13_lineitem") and metadata.get("lti13_token_url"))
+
+
+async def fetch_user_auth_state(username: str) -> dict:
+    """Fetch the user's auth_state from the JupyterHub API.
+
+    Requires the otter_grade service token to have the
+    `read:users:auth_state` scope (granted via the `read-users` role in
+    edx-hub's deployments/edx/config/common.yaml).
+
+    Returns the parsed `auth_state` dict (empty if the user has none).
+    """
+    api_url = os.environ["JUPYTERHUB_API_URL"].rstrip("/")
+    api_token = os.environ["JUPYTERHUB_API_TOKEN"]
+    url = f"{api_url}/users/{username}"
+    async with async_timeout.timeout(10):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, headers={"Authorization": f"token {api_token}"}
+            ) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    raise AGSError(
+                        f"failed to fetch auth_state for {username}: "
+                        f"HTTP {resp.status} {text[:200]}"
+                    )
+                data = await resp.json()
+    return data.get("auth_state") or {}
+
+
+def lti13_metadata_from_auth_state(auth_state: dict) -> dict:
+    """Project the `lti13_ags` block out of auth_state into the metadata
+    keys that `is_lti13_metadata` / `post_grade_lti13` expect.
+
+    Returns an empty dict if no LTI 1.3 launch fed this user's auth_state.
+    """
+    block = (auth_state or {}).get("lti13_ags") or {}
+    out: dict = {}
+    if block.get("lineitem"):
+        out["lti13_lineitem"] = block["lineitem"]
+    if block.get("token_url"):
+        out["lti13_token_url"] = block["token_url"]
+    if block.get("client_id"):
+        out["lti13_client_id"] = block["client_id"]
+    # The AGS userId must be the LTI 1.3 `sub` claim from the launch, not
+    # the JH username (which is a hash for LTI 1.1 launches and may differ
+    # from the platform-issued sub even on LTI 1.3).
+    if block.get("sub"):
+        out["lti13_user_id"] = block["sub"]
+    return out
 
 
 async def post_grade_lti13(metadata: dict, grade: float, max_score: float = 1.0) -> None:

--- a/src/otter_service/otter_nb.py
+++ b/src/otter_service/otter_nb.py
@@ -142,8 +142,9 @@ async def post_grade(solutions_base_path, metadata):
         - assignment:  the assignment name for this notebook
 
     Dispatches to LTI 1.3 (AGS) if metadata carries `lti13_lineitem` +
-    `lti13_token_url` (populated by otter-submit from JH auth_state on LTI 1.3
-    launches). Otherwise falls through to the existing LTI 1.1 XML/OAuth1 path.
+    `lti13_token_url` (pulled from the user's JH auth_state in
+    OtterHandler.post on LTI 1.3 launches). Otherwise falls through to the
+    existing LTI 1.1 XML/OAuth1 path.
     """
     if ags.is_lti13_metadata(metadata):
         user_id = metadata["userid"]
@@ -298,21 +299,28 @@ class OtterHandler(HubOAuthenticated, tornado.web.RequestHandler):
             if 'nb' in req_data:
                 notebook = req_data['nb']
 
-            # LTI 1.3 AGS endpoints (forwarded by otter-submit from JH
-            # auth_state when the user authenticated via LTI13Authenticator).
-            # When present, post_grade() dispatches to ags.post_grade_lti13()
-            # instead of the LTI 1.1 XML/OAuth1 path. Optional — LTI 1.1
-            # launches submit without this block and use the legacy path.
-            if 'lti13' in req_data:
-                lti13 = req_data['lti13'] or {}
-                metadata['lti13_lineitem'] = lti13.get('lineitem')
-                metadata['lti13_token_url'] = lti13.get('token_url')
-                metadata['lti13_client_id'] = lti13.get('client_id')
-                # AGS expects the LTI 1.3 `sub` claim as userId; otter-submit
-                # passes it through to ensure it matches what the platform
-                # registered the user as (may differ from the JH username).
-                if lti13.get('user_id'):
-                    metadata['userid'] = lti13['user_id']
+            # LTI 1.3 AGS: pull the lineitem URL + token_url + client_id +
+            # sub claim out of the user's JH auth_state (captured by the
+            # post_auth_hook at launch time). post_grade() checks for these
+            # fields via ags.is_lti13_metadata() and dispatches accordingly;
+            # LTI 1.1 launches won't have the block and fall through to the
+            # legacy XML/OAuth1 path. Requires the otter_grade service token
+            # to carry the read:users:auth_state scope (set in edx-hub's
+            # common.yaml).
+            if user is not None and user.get("name") and not using_test_user:
+                try:
+                    auth_state = await ags.fetch_user_auth_state(user["name"])
+                    lti13_md = ags.lti13_metadata_from_auth_state(auth_state)
+                    if lti13_md:
+                        metadata.update(lti13_md)
+                        # AGS userId must be the platform-issued `sub` claim,
+                        # which may differ from the JH username (the latter
+                        # is what get_current_user returns).
+                        if lti13_md.get("lti13_user_id"):
+                            metadata["userid"] = lti13_md["lti13_user_id"]
+                except ags.AGSError as ex:
+                    log_info_csv(user["name"], metadata,
+                                 f"auth_state fetch failed (LTI 1.3): {ex}")
 
             otter_check = "otter_service" in notebook['metadata']
             if otter_check and "course" in notebook['metadata']["otter_service"]:

--- a/tests/test_ags.py
+++ b/tests/test_ags.py
@@ -193,3 +193,40 @@ def test_token_cache_is_per_token_url(monkeypatch):
     assert ags._TOKEN_CACHE["https://a.example/token"][0] == "token-A"
     assert ags._TOKEN_CACHE["https://b.example/token"][0] == "token-B"
     ags._TOKEN_CACHE.clear()
+
+
+# ---------------------- lti13_metadata_from_auth_state ----------------------
+
+
+def test_lti13_metadata_from_auth_state_full_block():
+    auth_state = {
+        "lti13_ags": {
+            "sub": "edx-sub-29123",
+            "lineitem": "https://platform.example/lineitem/1",
+            "token_url": "https://platform.example/token",
+            "client_id": "my-tool",
+            "scopes": ["https://purl.imsglobal.org/spec/lti-ags/scope/score"],
+        }
+    }
+    out = ags.lti13_metadata_from_auth_state(auth_state)
+    assert out == {
+        "lti13_lineitem": "https://platform.example/lineitem/1",
+        "lti13_token_url": "https://platform.example/token",
+        "lti13_client_id": "my-tool",
+        "lti13_user_id": "edx-sub-29123",
+    }
+
+
+def test_lti13_metadata_from_auth_state_no_lti13_block():
+    assert ags.lti13_metadata_from_auth_state({}) == {}
+    assert ags.lti13_metadata_from_auth_state({"other": "stuff"}) == {}
+    assert ags.lti13_metadata_from_auth_state(None) == {}
+
+
+def test_lti13_metadata_from_auth_state_partial_block():
+    # Only lineitem present; other fields skipped.
+    auth_state = {"lti13_ags": {"lineitem": "https://x/y"}}
+    out = ags.lti13_metadata_from_auth_state(auth_state)
+    assert out == {"lti13_lineitem": "https://x/y"}
+    # is_lti13_metadata should return False (missing token_url).
+    assert ags.is_lti13_metadata(out) is False


### PR DESCRIPTION
## Summary

Replaces the prior plan (forward the `lti13` block through otter-submit → PyPI → edx-user-image → edx-hub) with a direct JH API call. The metadata flows hub → auth_state → otter-service, mirroring how LTI 1.1 already works (otter-service synthesizes the outcomes URL itself rather than receiving it from the browser).

- **`ags.fetch_user_auth_state(username)`** — GETs `/hub/api/users/<name>` with the `otter_grade` service token and returns the parsed `auth_state` dict
- **`ags.lti13_metadata_from_auth_state(auth_state)`** — projects the `lti13_ags` block into the metadata keys `post_grade()`/`post_grade_lti13()` expect
- **`OtterHandler.post`** calls both and updates `metadata`; failures log a CSV warning and fall through to the LTI 1.1 path (so LTI 1.1 launches stay unaffected if the API call ever fails)
- Drops the unused request-body `lti13` parser added in PR #48 — otter-submit doesn't carry metadata in either world

## Companion PR

Requires `read:users:auth_state` scope on the `otter_grade` JH service — edx-berkeley/edx-hub#73. Merge order:
1. edx-hub#73 (scope grant)
2. This PR + tag a new otter-service version
3. Bump in edx-hub `otter-service/values.yaml` → deploys to staging

## Test plan

- [x] All 15 unit tests pass locally (12 prior + 3 new for `lti13_metadata_from_auth_state`)
- [ ] After deploy: Saltire launch → notebook submit → verify staging otter-srv logs show `Posted to LTI 1.3 AGS: lineitem=... score=...`
- [ ] Verify Saltire's "Sample data" gradebook shows the score

🤖 Generated with [Claude Code](https://claude.com/claude-code)